### PR TITLE
Move bridge auth into implementation

### DIFF
--- a/src/DomainHost.sol
+++ b/src/DomainHost.sol
@@ -128,12 +128,6 @@ abstract contract DomainHost {
         _;
     }
 
-    function _isGuest(address usr) internal virtual view returns (bool);
-    modifier guestOnly {
-        require(_isGuest(msg.sender), "DomainHost/not-guest");
-        _;
-    }
-
     modifier ordered(uint256 _lid) {
         require(lid++ == _lid, "DomainHost/out-of-order");
         _;
@@ -237,7 +231,7 @@ abstract contract DomainHost {
     /// @notice Withdraw local DAI by burning remote canonical DAI
     /// @param to The address to send the DAI to on the local domain
     /// @param amount The amount of DAI to withdraw [WAD]
-    function withdraw(address to, uint256 amount) external guestOnly {
+    function _withdraw(address to, uint256 amount) internal {
         require(dai.transferFrom(escrow, to, amount), "DomainHost/transfer-failed");
 
         emit Withdraw(to, amount);
@@ -276,7 +270,7 @@ abstract contract DomainHost {
     /// @notice Withdraw pre-mint DAI from the remote domain
     /// @param _lid Local ordering id
     /// @param wad The amount of DAI to release [WAD]
-    function release(uint256 _lid, uint256 wad) external guestOnly ordered(_lid) {
+    function _release(uint256 _lid, uint256 wad) internal ordered(_lid) {
         require(vat.live() == 1, "DomainHost/vat-not-live");
 
         // Fix any permissionless repays that may have occurred
@@ -302,7 +296,7 @@ abstract contract DomainHost {
     /// @notice Guest is pushing a surplus (or deficit)
     /// @param _lid Local ordering id
     /// @param wad The amount of DAI to push (or pull) [WAD]
-    function push(uint256 _lid, int256 wad) external guestOnly ordered(_lid) {
+    function _push(uint256 _lid, int256 wad) internal ordered(_lid) {
         if (wad >= 0) {
             dai.transferFrom(address(escrow), address(this), uint256(wad));
             daiJoin.join(address(vow), uint256(wad));
@@ -347,7 +341,7 @@ abstract contract DomainHost {
     /// @notice Set this domain's cure value
     /// @param _lid Local ordering id
     /// @param value The value of the cure [RAD]
-    function tell(uint256 _lid, uint256 value) external guestOnly ordered(_lid) {
+    function _tell(uint256 _lid, uint256 value) internal ordered(_lid) {
         require(live == 0, "DomainHost/live");
         require(!cureReported, "DomainHost/cure-reported");
         require(_divup(value, RAY) <= grain, "DomainHost/cure-bad-value");
@@ -422,7 +416,7 @@ abstract contract DomainHost {
 
         emit InitializeRegisterMint(teleport);
     }
-    function finalizeRegisterMint(TeleportGUID calldata teleport) external guestOnly {
+    function _finalizeRegisterMint(TeleportGUID calldata teleport) internal {
         router.registerMint(teleport);
 
         emit FinalizeRegisterMint(teleport);
@@ -459,7 +453,7 @@ abstract contract DomainHost {
 
         emit UndoInitializeSettle(index, settlement.sourceDomain, settlement.targetDomain, settlement.amount);
     }
-    function finalizeSettle(bytes32 sourceDomain, bytes32 targetDomain, uint256 amount) external guestOnly {
+    function _finalizeSettle(bytes32 sourceDomain, bytes32 targetDomain, uint256 amount) internal {
         require(dai.transferFrom(escrow, address(this), amount), "DomainHost/transfer-failed");
         router.settle(sourceDomain, targetDomain, amount);
 

--- a/src/domains/arbitrum/ArbitrumDomainHost.sol
+++ b/src/domains/arbitrum/ArbitrumDomainHost.sol
@@ -84,9 +84,10 @@ contract ArbitrumDomainHost is DomainHost {
         emit File(what, data);
     }
 
-    function _isGuest(address usr) internal override view returns (bool) {
+    modifier guestOnly {
         address bridge = inbox.bridge();
-        return usr == bridge && guest == OutboxLike(BridgeLike(bridge).activeOutbox()).l2ToL1Sender();
+        require(msg.sender == bridge && guest == OutboxLike(BridgeLike(bridge).activeOutbox()).l2ToL1Sender(), "DomainHost/not-guest");
+        _;
     }
 
     function deposit(
@@ -123,6 +124,10 @@ contract ArbitrumDomainHost is DomainHost {
         );
     }
 
+    function withdraw(address to, uint256 amount) external guestOnly {
+        _withdraw(to, amount);
+    }
+
     function lift(
         uint256 wad,
         uint256 maxSubmissionCost,
@@ -152,6 +157,14 @@ contract ArbitrumDomainHost is DomainHost {
             glLift,
             gasPriceBid
         );
+    }
+
+    function release(uint256 _lid, uint256 wad) external guestOnly {
+        _release(_lid, wad);
+    }
+
+    function push(uint256 _lid, int256 wad) external guestOnly {
+        _push(_lid, wad);
     }
 
     function rectify(
@@ -208,6 +221,10 @@ contract ArbitrumDomainHost is DomainHost {
             glCage,
             gasPriceBid
         );
+    }
+
+    function tell(uint256 _lid, uint256 value) external guestOnly {
+        _tell(_lid, value);
     }
 
     function exit(
@@ -275,6 +292,10 @@ contract ArbitrumDomainHost is DomainHost {
         );
     }
 
+    function finalizeRegisterMint(TeleportGUID calldata teleport) external guestOnly {
+        _finalizeRegisterMint(teleport);
+    }
+
     function initializeSettle(
         uint256 index,
         uint256 maxSubmissionCost,
@@ -304,6 +325,10 @@ contract ArbitrumDomainHost is DomainHost {
             glDeposit,
             gasPriceBid
         );
+    }
+
+    function finalizeSettle(bytes32 sourceDomain, bytes32 targetDomain, uint256 amount) external guestOnly {
+        _finalizeSettle(sourceDomain, targetDomain, amount);
     }
 
 }

--- a/src/domains/optimism/OptimismDomainGuest.sol
+++ b/src/domains/optimism/OptimismDomainGuest.sol
@@ -66,8 +66,13 @@ contract OptimismDomainGuest is DomainGuest {
         emit FileGL(what, data);
     }
 
-    function _isHost(address usr) internal override view returns (bool) {
-        return usr == address(l2messenger) && l2messenger.xDomainMessageSender() == host;
+    modifier hostOnly {
+        require(msg.sender == address(l2messenger) && l2messenger.xDomainMessageSender() == host, "DomainGuest/not-host");
+        _;
+    }
+
+    function deposit(address to, uint256 amount) external hostOnly {
+        _deposit(to, amount);
     }
 
     function withdraw(address to, uint256 amount) external {
@@ -80,6 +85,10 @@ contract OptimismDomainGuest is DomainGuest {
             abi.encodeWithSelector(DomainHostLike.withdraw.selector, to, amount),
             gasLimit
         );
+    }
+
+    function lift(uint256 _lid, uint256 wad) external hostOnly {
+        _lift(_lid, wad);
     }
 
     function release() external {
@@ -106,6 +115,14 @@ contract OptimismDomainGuest is DomainGuest {
         );
     }
 
+    function rectify(uint256 _lid, uint256 wad) external hostOnly {
+        _rectify(_lid, wad);
+    }
+
+    function cage(uint256 _lid) external hostOnly {
+        _cage(_lid);
+    }
+
     function tell() external {
         tell(glTell);
     }
@@ -116,6 +133,10 @@ contract OptimismDomainGuest is DomainGuest {
             abi.encodeWithSelector(DomainHostLike.tell.selector, _rid, _cure),
             gasLimit
         );
+    }
+
+    function exit(address usr, uint256 wad) external hostOnly {
+        _exit(usr, wad);
     }
 
     function initializeRegisterMint(TeleportGUID calldata teleport) external {
@@ -130,6 +151,10 @@ contract OptimismDomainGuest is DomainGuest {
         );
     }
 
+    function finalizeRegisterMint(TeleportGUID calldata teleport) external hostOnly {
+        _finalizeRegisterMint(teleport);
+    }
+
     function initializeSettle(uint256 index) external {
         initializeSettle(index, glInitializeSettle);
     }
@@ -140,6 +165,10 @@ contract OptimismDomainGuest is DomainGuest {
             abi.encodeWithSelector(DomainHostLike.finalizeSettle.selector, _sourceDomain, _targetDomain, _amount),
             gasLimit
         );
+    }
+
+    function finalizeSettle(bytes32 sourceDomain, bytes32 targetDomain, uint256 amount) external hostOnly {
+        _finalizeSettle(sourceDomain, targetDomain, amount);
     }
 
 }

--- a/src/domains/optimism/OptimismDomainHost.sol
+++ b/src/domains/optimism/OptimismDomainHost.sol
@@ -67,8 +67,9 @@ contract OptimismDomainHost is DomainHost {
         emit File(what, data);
     }
 
-    function _isGuest(address usr) internal override view returns (bool) {
-        return usr == address(l1messenger) && l1messenger.xDomainMessageSender() == guest;
+    modifier guestOnly {
+        require(msg.sender == address(l1messenger) && l1messenger.xDomainMessageSender() == guest, "DomainHost/not-guest");
+        _;
     }
 
     function deposit(address to, uint256 amount) external {
@@ -83,6 +84,10 @@ contract OptimismDomainHost is DomainHost {
         );
     }
 
+    function withdraw(address to, uint256 amount) external guestOnly {
+        _withdraw(to, amount);
+    }
+
     function lift(uint256 wad) external {
         lift(wad, glLift);
     }
@@ -93,6 +98,14 @@ contract OptimismDomainHost is DomainHost {
             abi.encodeWithSelector(DomainGuestLike.lift.selector, _rid, wad),
             gasLimit
         );
+    }
+
+    function release(uint256 _lid, uint256 wad) external guestOnly {
+        _release(_lid, wad);
+    }
+
+    function push(uint256 _lid, int256 wad) external guestOnly {
+        _push(_lid, wad);
     }
 
     function rectify() external {
@@ -119,6 +132,10 @@ contract OptimismDomainHost is DomainHost {
         );
     }
 
+    function tell(uint256 _lid, uint256 value) external guestOnly {
+        _tell(_lid, value);
+    }
+
     function exit(address usr, uint256 wad) external {
         exit(usr, wad, glExit);
     }
@@ -143,6 +160,10 @@ contract OptimismDomainHost is DomainHost {
         );
     }
 
+    function finalizeRegisterMint(TeleportGUID calldata teleport) external guestOnly {
+        _finalizeRegisterMint(teleport);
+    }
+
     function initializeSettle(uint256 index) external {
         initializeSettle(index, glInitializeSettle);
     }
@@ -153,6 +174,10 @@ contract OptimismDomainHost is DomainHost {
             abi.encodeWithSelector(DomainGuestLike.finalizeSettle.selector, _sourceDomain, _targetDomain, _amount),
             gasLimit
         );
+    }
+
+    function finalizeSettle(bytes32 sourceDomain, bytes32 targetDomain, uint256 amount) external guestOnly {
+        _finalizeSettle(sourceDomain, targetDomain, amount);
     }
 
 }


### PR DESCRIPTION
Fairly big change, so I made it a PR. From https://github.com/makerdao/dss-bridge/pull/5

Basically old system was too prescriptive and zk-rollups don't fit into this.