### PR TITLE
Add partial accrues / rectifies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Permissionless function which will push a deficit to the host domain if the delt
 
 This will trigger a call to `DomainHost.deficit(uint256 _lid, uint256 wad)` with `wad >= dust`.
 
-### `DomainHost.accrue(uint256 _grain)`
+### `DomainHost.accrue(uint256 _grain, uint256 _maxAmount)`
 
-Authed function which will effectively move the accounted surplus to the buffer. It will generate new pre minted DAI if necessary to cover remote's debt (it is up to governance to pass the correct value).
+Authed function which will effectively move the accounted surplus to the buffer. It will generate new pre minted DAI if necessary to cover remote's debt (it is up to governance to pass the correct value). A `_maxAmount` should be specified to prevent front-running from malicious domain.
 
-### `DomainHost.rectify()`
+### `DomainHost.rectify(uint256 _maxAmount)`
 
-Suck some DAI from the surplus buffer and send it to the Guest to cover the bad debt.
+Suck some DAI from the surplus buffer and send it to the Guest to cover the bad debt. A `_maxAmount` should be specified to prevent front-running from malicious domain.
 
 This will trigger a call to `DomainGuest.rectify(uint256 _lid, uint256 wad)`.
 

--- a/src/domains/arbitrum/ArbitrumDomainHost.sol
+++ b/src/domains/arbitrum/ArbitrumDomainHost.sol
@@ -169,11 +169,12 @@ contract ArbitrumDomainHost is DomainHost {
     }
 
     function rectify(
+        uint256 _maxAmount,
         uint256 maxSubmissionCost,
         uint256 maxGas,
         uint256 gasPriceBid
     ) public payable {
-        (uint256 _rid, uint256 _wad) = _rectify();
+        (uint256 _rid, uint256 _wad) = _rectify(_maxAmount);
         inbox.createRetryableTicket{value: msg.value}(
             guest,
             0, // we always assume that l2CallValue = 0
@@ -186,10 +187,12 @@ contract ArbitrumDomainHost is DomainHost {
         );
     }
     function rectify(
+        uint256 _maxAmount,
         uint256 maxSubmissionCost,
         uint256 gasPriceBid
     ) external payable {
         rectify(
+            _maxAmount,
             maxSubmissionCost,
             glLift,
             gasPriceBid

--- a/src/domains/optimism/OptimismDomainHost.sol
+++ b/src/domains/optimism/OptimismDomainHost.sol
@@ -108,11 +108,11 @@ contract OptimismDomainHost is DomainHost {
         _deficit(_lid, wad);
     }
 
-    function rectify() external {
-        rectify(glRectify);
+    function rectify(uint256 _maxAmount) external {
+        rectify(_maxAmount, glRectify);
     }
-    function rectify(uint32 gasLimit) public {
-        (uint256 _rid, uint256 _wad) = _rectify();
+    function rectify(uint256 _maxAmount, uint32 gasLimit) public {
+        (uint256 _rid, uint256 _wad) = _rectify(_maxAmount);
         l1messenger.sendMessage(
             guest,
             abi.encodeWithSelector(DomainGuestLike.rectify.selector, _rid, _wad),

--- a/src/tests/domains/ArbitrumIntegration.t.sol
+++ b/src/tests/domains/ArbitrumIntegration.t.sol
@@ -57,8 +57,8 @@ abstract contract ArbitrumIntegrationTest is IntegrationBaseTest {
         ArbitrumDomainHost(address(host)).lift{value:1 ether}(wad, 1 ether, 0);
     }
 
-    function hostRectify() internal virtual override {
-        ArbitrumDomainHost(address(host)).rectify{value:1 ether}(1 ether, 0);
+    function hostRectify(uint256 _maxAmount) internal virtual override {
+        ArbitrumDomainHost(address(host)).rectify{value:1 ether}(_maxAmount, 1 ether, 0);
     }
 
     function hostCage() internal virtual override {

--- a/src/tests/domains/IntegrationBase.t.sol
+++ b/src/tests/domains/IntegrationBase.t.sol
@@ -208,7 +208,7 @@ abstract contract IntegrationBaseTest is DssTest {
     }
 
     function hostLift(uint256 wad) internal virtual;
-    function hostRectify() internal virtual;
+    function hostRectify(uint256 _maxAmount) internal virtual;
     function hostCage() internal virtual;
     function hostExit(address usr, uint256 wad) internal virtual;
     function hostDeposit(address to, uint256 amount) internal virtual;
@@ -339,7 +339,7 @@ abstract contract IntegrationBaseTest is DssTest {
 
         assertEq(host.ddai(), 30 ether);
 
-        host.accrue(0);
+        host.accrue(0, type(uint256).max);
 
         assertEq(dss.vat.dai(address(dss.vow)), vowDai + 30 * RAD);
         assertEq(dss.vat.sin(address(dss.vow)), vowSin);
@@ -377,7 +377,7 @@ abstract contract IntegrationBaseTest is DssTest {
         assertEq(Vat(address(rdss.vat)).surf(), existingSurf);
         hostDomain.selectFork();
 
-        hostRectify();
+        hostRectify(type(uint256).max);
         assertEq(dss.vat.dai(address(dss.vow)), vowDai);
         assertEq(dss.vat.sin(address(dss.vow)), vowSin + 30 * RAD);
         assertEq(dss.dai.balanceOf(escrow), escrowDai + 130 ether);
@@ -764,7 +764,7 @@ abstract contract IntegrationBaseTest is DssTest {
         guestDomain.relayToHost(true);
         assertEq(host.ddai(), 2.85 ether);
 
-        host.accrue(97.85 ether);
+        host.accrue(97.85 ether, type(uint256).max);
 
         assertEq(dss.vat.dai(address(dss.vow)), 2.85 * 10**45);
         assertEq(dss.dai.balanceOf(address(escrow)), 117.15 ether);
@@ -939,7 +939,7 @@ abstract contract IntegrationBaseTest is DssTest {
         guestDomain.relayToHost(true);
         assertEq(host.ddai(), 9.5 ether);
 
-        host.accrue(104.5 ether);
+        host.accrue(104.5 ether, type(uint256).max);
 
         assertEq(dss.vat.dai(address(dss.vow)), 9.5 * 10**45);
         assertEq(dss.dai.balanceOf(address(escrow)), 115 ether);
@@ -1134,7 +1134,7 @@ abstract contract IntegrationBaseTest is DssTest {
 
         assertEq(host.dsin(), 50 ether);
 
-        hostRectify();
+        hostRectify(type(uint256).max);
 
         assertEq(dss.vat.debt(), existingVatDebt + 150 * RAD);
         assertEq(dss.dai.balanceOf(address(escrow)), 170 ether);
@@ -1204,7 +1204,7 @@ abstract contract IntegrationBaseTest is DssTest {
 
         assertEq(host.dsin(), 50 ether);
 
-        hostRectify();
+        hostRectify(type(uint256).max);
 
         assertEq(dss.vat.debt(), existingVatDebt + 150 * RAD);
         assertEq(dss.dai.balanceOf(address(escrow)), 170 ether);

--- a/src/tests/domains/OptimismIntegration.t.sol
+++ b/src/tests/domains/OptimismIntegration.t.sol
@@ -69,8 +69,8 @@ contract OptimismIntegrationTest is IntegrationBaseTest {
         OptimismDomainHost(address(host)).lift(wad);
     }
 
-    function hostRectify() internal virtual override {
-        OptimismDomainHost(address(host)).rectify();
+    function hostRectify(uint256 _maxAmount) internal virtual override {
+        OptimismDomainHost(address(host)).rectify(_maxAmount);
     }
 
     function hostCage() internal virtual override {


### PR DESCRIPTION
As discussed [here](https://github.com/makerdao/dss-bridge/issues/18) and [here](https://github.com/makerdao/dss-bridge/issues/20) this PR will allow governance to specify partial rectifies/accrues to not only give more flexibility, but prevent front-running of malicious domain.