### PR TITLE
Add file for all the bridge params in case it gets in a broken state

### DIFF
--- a/src/DomainGuest.sol
+++ b/src/DomainGuest.sol
@@ -172,7 +172,10 @@ abstract contract DomainGuest {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if (what == "dust") dust = data;
+        if (what == "lid") lid = data;
+        else if (what == "rid") rid = data;
+        else if (what == "dsin") dsin = data;
+        else if (what == "dust") dust = data;
         else revert("DomainGuest/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DomainHost.sol
+++ b/src/DomainHost.sol
@@ -93,6 +93,7 @@ abstract contract DomainHost {
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
+    event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
     event Lift(uint256 rad);
     event Release(uint256 wad);
@@ -170,6 +171,17 @@ abstract contract DomainHost {
 
     function file(bytes32 what, address data) external auth {
         if (what == "vow") vow = data;
+        else revert("DomainHost/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if (what == "lid") lid = data;
+        else if (what == "rid") rid = data;
+        else if (what == "line") line = data;
+        else if (what == "grain") grain = data;
+        else if (what == "ddai") ddai = data;
+        else if (what == "dsin") dsin = data;
         else revert("DomainHost/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DomainHost.sol
+++ b/src/DomainHost.sol
@@ -182,6 +182,7 @@ abstract contract DomainHost {
         else if (what == "grain") grain = data;
         else if (what == "ddai") ddai = data;
         else if (what == "dsin") dsin = data;
+        else if (what == "live") live = data;
         else revert("DomainHost/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/domains/arbitrum/ArbitrumDomainHost.sol
+++ b/src/domains/arbitrum/ArbitrumDomainHost.sol
@@ -58,7 +58,7 @@ contract ArbitrumDomainHost is DomainHost {
     uint256 public glInitializeSettle;
 
     // --- Events ---
-    event File(bytes32 indexed what, uint256 data);
+    event FileGL(bytes32 indexed what, uint256 data);
 
     constructor(
         bytes32 _ilk,
@@ -72,7 +72,7 @@ contract ArbitrumDomainHost is DomainHost {
         guest = _guest;
     }
 
-    function file(bytes32 what, uint256 data) external auth {
+    function filegl(bytes32 what, uint256 data) external auth {
         if (what == "glLift") glLift = data;
         else if (what == "glRectify") glRectify = data;
         else if (what == "glCage") glCage = data;
@@ -81,7 +81,7 @@ contract ArbitrumDomainHost is DomainHost {
         else if (what == "glInitializeRegisterMint") glInitializeRegisterMint = data;
         else if (what == "glInitializeSettle") glInitializeSettle = data;
         else revert("ArbitrumDomainHost/file-unrecognized-param");
-        emit File(what, data);
+        emit FileGL(what, data);
     }
 
     modifier guestOnly {

--- a/src/domains/optimism/OptimismDomainHost.sol
+++ b/src/domains/optimism/OptimismDomainHost.sol
@@ -41,7 +41,7 @@ contract OptimismDomainHost is DomainHost {
     uint32 public glInitializeSettle;
 
     // --- Events ---
-    event File(bytes32 indexed what, uint32 data);
+    event FileGL(bytes32 indexed what, uint32 data);
 
     constructor(
         bytes32 _ilk,
@@ -55,7 +55,7 @@ contract OptimismDomainHost is DomainHost {
         guest = _guest;
     }
 
-    function file(bytes32 what, uint32 data) external auth {
+    function filegl(bytes32 what, uint32 data) external auth {
         if (what == "glLift") glLift = data;
         else if (what == "glRectify") glRectify = data;
         else if (what == "glCage") glCage = data;
@@ -64,7 +64,7 @@ contract OptimismDomainHost is DomainHost {
         else if (what == "glInitializeRegisterMint") glInitializeRegisterMint = data;
         else if (what == "glInitializeSettle") glInitializeSettle = data;
         else revert("OptimismDomainHost/file-unrecognized-param");
-        emit File(what, data);
+        emit FileGL(what, data);
     }
 
     modifier guestOnly {

--- a/src/tests/DomainGuest.t.sol
+++ b/src/tests/DomainGuest.t.sol
@@ -146,7 +146,12 @@ contract DomainGuestTest is DssTest {
 
     function testFile() public {
         checkFileAddress(address(guest), "DomainGuest", ["end"]);
-        checkFileUint(address(guest), "DomainGuest", ["dust"]);
+        checkFileUint(address(guest), "DomainGuest", [
+            "lid",
+            "rid",
+            "dsin",
+            "dust"
+        ]);
     }
 
     function testHostOnly() public {

--- a/src/tests/DomainHost.t.sol
+++ b/src/tests/DomainHost.t.sol
@@ -175,6 +175,14 @@ contract DomainHostTest is DssTest {
 
     function testFile() public {
         checkFileAddress(address(host), "DomainHost", ["vow"]);
+        checkFileUint(address(host), "DomainHost", [
+            "lid",
+            "rid",
+            "line",
+            "grain",
+            "ddai",
+            "dsin"
+        ]);
     }
 
     function testAuth() public {

--- a/src/tests/DomainHost.t.sol
+++ b/src/tests/DomainHost.t.sol
@@ -183,6 +183,10 @@ contract DomainHostTest is DssTest {
             "ddai",
             "dsin"
         ]);
+        // Hit the limit so broke out into new test
+        checkFileUint(address(host), "DomainHost", [
+            "live"
+        ]);
     }
 
     function testAuth() public {

--- a/src/tests/domains/ArbitrumIntegration.t.sol
+++ b/src/tests/domains/ArbitrumIntegration.t.sol
@@ -41,13 +41,13 @@ abstract contract ArbitrumIntegrationTest is IntegrationBaseTest {
 
     function initHost() internal virtual override {
         ArbitrumDomainHost _host = ArbitrumDomainHost(address(host));
-        _host.file("glLift", 1_000_000);
-        _host.file("glRectify", 1_000_000);
-        _host.file("glCage", 1_000_000);
-        _host.file("glExit", 1_000_000);
-        _host.file("glDeposit", 1_000_000);
-        _host.file("glInitializeRegisterMint", 1_000_000);
-        _host.file("glInitializeSettle", 1_000_000);
+        _host.filegl("glLift", 1_000_000);
+        _host.filegl("glRectify", 1_000_000);
+        _host.filegl("glCage", 1_000_000);
+        _host.filegl("glExit", 1_000_000);
+        _host.filegl("glDeposit", 1_000_000);
+        _host.filegl("glInitializeRegisterMint", 1_000_000);
+        _host.filegl("glInitializeSettle", 1_000_000);
     }
 
     function initGuest() internal virtual override {

--- a/src/tests/domains/OptimismIntegration.t.sol
+++ b/src/tests/domains/OptimismIntegration.t.sol
@@ -45,13 +45,13 @@ contract OptimismIntegrationTest is IntegrationBaseTest {
 
     function initHost() internal virtual override {
         OptimismDomainHost _host = OptimismDomainHost(address(host));
-        _host.file("glLift", 1_000_000);
-        _host.file("glRectify", 1_000_000);
-        _host.file("glCage", 1_000_000);
-        _host.file("glExit", 1_000_000);
-        _host.file("glDeposit", 1_000_000);
-        _host.file("glInitializeRegisterMint", 1_000_000);
-        _host.file("glInitializeSettle", 1_000_000);
+        _host.filegl("glLift", 1_000_000);
+        _host.filegl("glRectify", 1_000_000);
+        _host.filegl("glCage", 1_000_000);
+        _host.filegl("glExit", 1_000_000);
+        _host.filegl("glDeposit", 1_000_000);
+        _host.filegl("glInitializeRegisterMint", 1_000_000);
+        _host.filegl("glInitializeSettle", 1_000_000);
     }
 
     function initGuest() internal virtual override {


### PR DESCRIPTION
We should expect the bridge to function normally most of the time, but we want a method to be able to recover in case of unexpected behavior (message gets dropped, censored, etc). This will add `file(...)` on most parameters to allow for such recovery.

I've omitted the global settlement parameters because I don't think it adds any value being able to set those. The `tell()` message can be replayed as many times as needed and governance can intervene if needed (manually repay the debt with escrow funds) if for some reason it still has admin access and the domain is broken.